### PR TITLE
Add manually configured DNS servers as upstream

### DIFF
--- a/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
+++ b/roles/openshift_node_dnsmasq/files/networkmanager/99-origin-dns.sh
@@ -43,9 +43,19 @@ EOF
     fi
     # zero out our upstream servers list and feed it into dnsmasq
     echo '' > /etc/dnsmasq.d/origin-upstream-dns.conf
-    for ns in ${DHCP4_DOMAIN_NAME_SERVERS}; do
-       echo "server=${ns}" >> /etc/dnsmasq.d/origin-upstream-dns.conf
-    done
+
+    if [ -n "${DHCP4_DOMAIN_NAME_SERVERS}" ]; then
+        for ns in ${DHCP4_DOMAIN_NAME_SERVERS}; do
+            echo "server=${ns}" >> /etc/dnsmasq.d/origin-upstream-dns.conf
+        done
+    fi
+
+    if [ -n "${IP4_NAMESERVERS}" ]; then
+        for ns in ${IP4_NAMESERVERS}; do
+            echo "server=${ns}" >> /etc/dnsmasq.d/origin-upstream-dns.conf
+        done
+    fi
+
     systemctl restart dnsmasq
 
     sed -i 's/^nameserver.*$/nameserver '"${def_route_ip}"'/g' /etc/resolv.conf


### PR DESCRIPTION
Add manually configured DNS servers as upstream servers for dnsmasq (file /etc/dnsmasq.d/origin-upstream-dns.conf).

Issue with the original code: if IP address and DNS server are configured statically, the variable DHCP4_DOMAIN_NAME_SERVERS is empty and no upstream servers are stored in /etc/dnsmasq.d/origin-upstream-dns.conf as upstream DNS resolvers. This leads to no DNS name resolution for statically configured network settings.